### PR TITLE
fix(event): Parse event start dates into Date objects

### DIFF
--- a/src/app/services/event.service.ts
+++ b/src/app/services/event.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { TournamentEvent } from './model/tournament-event.model';
 import { HttpClient } from '@angular/common/http';
+import { map } from 'rxjs/operators';
 
 @Injectable({
 	providedIn: 'root'
@@ -12,6 +13,11 @@ export class EventService {
 	constructor() { }
 
 	getEvents(): Observable<TournamentEvent[]> {
-		return this.http.get<TournamentEvent[]>('events.json');
+		return this.http.get<TournamentEvent[]>('events.json').pipe(
+			map(events => events.map(event => ({
+				...event,
+				start: new Date(event.start)
+			})))
+		);
 	}
 }


### PR DESCRIPTION
The event service was fetching event data from a JSON file where dates were stored as strings. However, the application's model and calendar component expect the `start` property to be a `Date` object.

This change introduces an RxJS `map` operator to the `getEvents` method. This operator transforms the array of events, converting the `start` string of each event into a proper `Date` object before passing the data to the components. This ensures the calendar can correctly interpret and display the events.