### PR TITLE
feat: Replace event detail page with modal and improve UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mma-event-colendar",
       "version": "0.0.0",
       "dependencies": {
+        "@angular/animations": "^20.2.3",
         "@angular/cdk": "^20.2.1",
         "@angular/common": "^20.2.0",
         "@angular/compiler": "^20.2.0",
@@ -319,6 +320,22 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular/animations": {
+      "version": "20.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.2.3.tgz",
+      "integrity": "sha512-cyON3oVfaotz8d8DHP3uheC/XDG2gJD8aiyuG/SEAZ2X1S/tAHdVetESbDZM830lLdi+kB/3GBrMbWCCpMWD7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "20.2.3",
+        "@angular/core": "20.2.3"
       }
     },
     "node_modules/@angular/build": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "private": true,
   "dependencies": {
+    "@angular/animations": "^20.2.3",
     "@angular/cdk": "^20.2.1",
     "@angular/common": "^20.2.0",
     "@angular/compiler": "^20.2.0",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,14 +1,18 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, importProvidersFrom, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { MatDialogModule } from '@angular/material/dialog';
 
 import { routes } from './app.routes';
-import { provideHttpClient } from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
 	providers: [
 		provideBrowserGlobalErrorListeners(),
 		provideZoneChangeDetection({ eventCoalescing: true }),
 		provideRouter(routes),
-		provideHttpClient()
-	]
+		provideHttpClient(withInterceptorsFromDi()),
+		provideAnimations(),
+		importProvidersFrom(MatDialogModule),
+	],
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,8 +1,4 @@
 import { Routes } from '@angular/router';
 import { Calendar } from './components/page/calendar/calendar';
-import { EventDetail } from './components/page/event-detail/event-detail';
 
-export const routes: Routes = [
-  { path: '', component: Calendar },
-  { path: 'event/:id', component: EventDetail },
-];
+export const routes: Routes = [{ path: '', component: Calendar }];

--- a/src/app/components/page/calendar/calendar.html
+++ b/src/app/components/page/calendar/calendar.html
@@ -22,10 +22,8 @@
 				</div>
 				<div class="events">
 					@for (event of day.events; track event.id) {
-						<mat-card class="event-card">
-							<a [routerLink]="['/event', event.id]">
-								<mat-card-title class="event-title" matTooltip="{{ event.title }}">{{ event.title }}</mat-card-title>
-							</a>
+						<mat-card class="event-card" (click)="openEventModal(event)">
+							<mat-card-title class="event-title" matTooltip="{{ event.title }}">{{ event.title }}</mat-card-title>
 						</mat-card>
 					}
 				</div>

--- a/src/app/components/page/event-detail/event-detail.html
+++ b/src/app/components/page/event-detail/event-detail.html
@@ -1,26 +1,35 @@
 <div class="detail-container">
-  @if (event(); as ev) {
-    <h1 class="event-title">{{ ev.title }}</h1>
-    <div class="event-meta">
-      <p><strong>開催日時:</strong> {{ ev.start | date:'yyyy年M月d日 H:mm' }}</p>
-      <p><strong>開催場所:</strong> {{ ev.meta.location }}</p>
-    </div>
+	@if (event(); as ev) {
+		<h1 class="event-title">{{ ev.title }}</h1>
+		<div class="event-meta">
+			<p><strong>開催日時:</strong> {{ ev.start | date: 'yyyy年M月d日 H:mm' }}</p>
+			<p><strong>開催場所:</strong> {{ ev.meta.location }}</p>
+		</div>
 
-    <mat-card class="fight-card">
-      <mat-card-header>
-        <mat-card-title>対戦カード</mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <ul class="fight-list">
-          @for (fight of ev.meta.card; track fight) {
-            <li class="fight-item">{{ fight }}</li>
-          }
-        </ul>
-      </mat-card-content>
-    </mat-card>
+		<mat-card class="fight-card">
+			<mat-card-header>
+				<mat-card-title>対戦カード</mat-card-title>
+			</mat-card-header>
+			<mat-card-content>
+				<mat-list>
+					@for (fight of ev.meta.card; track fight) {
+						<mat-list-item>{{ fight }}</mat-list-item>
+					}
+				</mat-list>
+			</mat-card-content>
+		</mat-card>
 
-    <a routerLink="/" class="back-link">カレンダーに戻る</a>
-  } @else {
-    <p>イベント情報を読み込んでいます...</p>
-  }
+		<a
+			mat-raised-button
+			color="primary"
+			[href]="ev.meta.description"
+			target="_blank"
+			rel="noopener noreferrer"
+			class="source-link"
+		>
+			情報取得元サイトへ
+		</a>
+	} @else {
+		<p>イベント情報を読み込んでいます...</p>
+	}
 </div>

--- a/src/app/components/page/event-detail/event-detail.spec.ts
+++ b/src/app/components/page/event-detail/event-detail.spec.ts
@@ -1,55 +1,41 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
-import { of } from 'rxjs';
-import { EventService } from '../../../services/event.service';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { EventDetail } from './event-detail';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 describe('EventDetail', () => {
-  let component: EventDetail;
-  let fixture: ComponentFixture<EventDetail>;
-  let mockEventService: jasmine.SpyObj<EventService>;
+	let component: EventDetail;
+	let fixture: ComponentFixture<EventDetail>;
 
-  const mockActivatedRoute = {
-    snapshot: {
-      paramMap: {
-        get: (key: string) => '123', // return a mock ID
-      },
-    },
-  };
+	const mockDialogData = {
+		id: '123',
+		title: 'Test Event',
+		start: new Date(),
+		meta: {
+			location: 'Test Location',
+			organization: 'Test Org',
+			description: 'http://test.com',
+			source: 'Test Source',
+			card: ['Fight 1', 'Fight 2'],
+			results: [],
+		},
+	};
 
-  beforeEach(async () => {
-    // Create a spy object for the EventService
-    mockEventService = jasmine.createSpyObj('EventService', ['getEventById']);
-    // Configure the spy to return a mock event
-    mockEventService.getEventById.and.returnValue(of({
-      id: '123',
-      title: 'Test Event',
-      start: new Date(),
-      meta: {
-        location: 'Test Location',
-        organization: 'Test Org',
-        description: '',
-        source: '',
-        card: ['Fight 1', 'Fight 2'],
-        results: [],
-      }
-    }));
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			imports: [EventDetail],
+			providers: [
+				{ provide: MAT_DIALOG_DATA, useValue: mockDialogData },
+				provideNoopAnimations(),
+			],
+		}).compileComponents();
 
-    await TestBed.configureTestingModule({
-      imports: [EventDetail, HttpClientTestingModule],
-      providers: [
-        { provide: ActivatedRoute, useValue: mockActivatedRoute },
-        { provide: EventService, useValue: mockEventService }
-      ],
-    }).compileComponents();
+		fixture = TestBed.createComponent(EventDetail);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
 
-    fixture = TestBed.createComponent(EventDetail);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
 });

--- a/src/app/components/page/event-detail/event-detail.ts
+++ b/src/app/components/page/event-detail/event-detail.ts
@@ -1,28 +1,24 @@
-import { ChangeDetectionStrategy, Component, inject, signal, OnInit } from '@angular/core';
-import { ActivatedRoute, RouterLink } from '@angular/router';
-import { EventService } from '../../../services/event.service';
-import { TournamentEvent } from '../../../services/model/tournament-event.model';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
+import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatListModule } from '@angular/material/list';
+import { MatButtonModule } from '@angular/material/button';
+import { TournamentEvent } from '../../../services/model/tournament-event.model';
 
 @Component({
-  selector: 'app-event-detail',
-  imports: [CommonModule, RouterLink, MatCardModule, DatePipe],
-  templateUrl: './event-detail.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
+	selector: 'app-event-detail',
+	imports: [
+		CommonModule,
+		MatCardModule,
+		DatePipe,
+		MatDialogModule,
+		MatListModule,
+		MatButtonModule,
+	],
+	templateUrl: './event-detail.html',
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class EventDetail implements OnInit {
-  private route = inject(ActivatedRoute);
-  private eventService = inject(EventService);
-
-  event = signal<TournamentEvent | undefined>(undefined);
-
-  ngOnInit(): void {
-    const eventId = this.route.snapshot.paramMap.get('id');
-    if (eventId) {
-      this.eventService.getEventById(eventId).subscribe(event => {
-        this.event.set(event);
-      });
-    }
-  }
+export class EventDetail {
+	event = signal<TournamentEvent>(inject(MAT_DIALOG_DATA));
 }


### PR DESCRIPTION
- Replaced the event detail page with an Angular Material dialog (modal) for a better user experience.
- Refactored the EventDetail component to receive data via MAT_DIALOG_DATA.
- Updated the Calendar component to open the modal on event click.
- Improved the display of the fight card by using mat-list for better readability.
- Added a mat-raised-button to link to the original source URL for the event.
- Removed the now-unused route for the event detail page.
- Updated unit tests for the EventDetail component to provide mock dialog data.
- Added @angular/animations package to support dialog animations.