### PR TITLE
Fix: Update event detail modal display

### DIFF
--- a/src/app/components/page/calendar/calendar.ts
+++ b/src/app/components/page/calendar/calendar.ts
@@ -103,7 +103,7 @@ export class Calendar {
 		this.dialog.open(EventDetail, {
 			data: event,
 			width: '80%',
-			maxWidth: '600px',
+			maxWidth: '900px',
 			autoFocus: false,
 		});
 	}

--- a/src/app/components/page/event-detail/event-detail.html
+++ b/src/app/components/page/event-detail/event-detail.html
@@ -28,6 +28,7 @@
 		</mat-card>
 	</mat-dialog-content>
 	<mat-dialog-actions>
+		<button mat-button mat-dialog-close class="close-button">閉じる</button>
 		<a
 			mat-raised-button
 			color="primary"

--- a/src/app/components/page/event-detail/event-detail.scss
+++ b/src/app/components/page/event-detail/event-detail.scss
@@ -66,12 +66,21 @@
 	}
 }
 
+:host {
+	.close-button {
+		display: none; // デフォルトでは非表示
+	}
+}
+
 @media (max-width: 768px) {
 	:host {
 		.fight-card {
 			.player {
 				font-size: 14px; // Smaller font on mobile
 			}
+		}
+		.close-button {
+			display: block; // モバイルで表示
 		}
 	}
 }


### PR DESCRIPTION
- Increase the max-width of the event detail modal to 900px to prevent wrapping of fight cards on larger screens.
- Add a close button to the modal that is only visible on mobile devices.